### PR TITLE
feat: reuse ceresdb client

### DIFF
--- a/load/loader.go
+++ b/load/loader.go
@@ -3,7 +3,6 @@ package load
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/timescale/tsbs/pkg/targets"
 	"io/ioutil"
 	"log"
 	"math/rand"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/timescale/tsbs/load/insertstrategy"
+	"github.com/timescale/tsbs/pkg/targets"
 )
 
 const (

--- a/pkg/targets/ceresdb/benchmark.go
+++ b/pkg/targets/ceresdb/benchmark.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/CeresDB/ceresdb-client-go/ceresdb"
 	"github.com/blagojts/viper"
 	"github.com/timescale/tsbs/load"
 	"github.com/timescale/tsbs/pkg/data/source"
@@ -31,6 +32,7 @@ func parseSpecificConfig(v *viper.Viper) (*SpecificConfig, error) {
 type benchmark struct {
 	config     *SpecificConfig
 	dataSource targets.DataSource
+	client     ceresdb.Client
 }
 
 func NewBenchmark(config *SpecificConfig, dataSourceConfig *source.DataSourceConfig) (targets.Benchmark, error) {
@@ -39,11 +41,16 @@ func NewBenchmark(config *SpecificConfig, dataSourceConfig *source.DataSourceCon
 	}
 
 	br := load.GetBufferedReader(dataSourceConfig.File.Location)
+	client, err := ceresdb.NewClient(config.CeresdbAddr, ceresdb.Direct, ceresdb.WithDefaultDatabase("public"))
+	if err != nil {
+		panic(err)
+	}
 	return &benchmark{
 		dataSource: &fileDataSource{
 			scanner: bufio.NewScanner(br),
 		},
 		config: config,
+		client: client,
 	}, nil
 }
 
@@ -65,7 +72,7 @@ func (b *benchmark) GetPointIndexer(maxPartitions uint) targets.PointIndexer {
 }
 
 func (b *benchmark) GetProcessor() targets.Processor {
-	return &processor{addr: b.config.CeresdbAddr}
+	return &processor{addr: b.config.CeresdbAddr, client: b.client}
 }
 
 func (b *benchmark) GetDBCreator() targets.DBCreator {

--- a/pkg/targets/ceresdb/benchmark.go
+++ b/pkg/targets/ceresdb/benchmark.go
@@ -41,16 +41,17 @@ func NewBenchmark(config *SpecificConfig, dataSourceConfig *source.DataSourceCon
 	}
 
 	br := load.GetBufferedReader(dataSourceConfig.File.Location)
+	dataSource := &fileDataSource{
+		scanner: bufio.NewScanner(br),
+	}
 	client, err := ceresdb.NewClient(config.CeresdbAddr, ceresdb.Direct, ceresdb.WithDefaultDatabase("public"))
 	if err != nil {
 		panic(err)
 	}
 	return &benchmark{
-		dataSource: &fileDataSource{
-			scanner: bufio.NewScanner(br),
-		},
-		config: config,
-		client: client,
+		config,
+		dataSource,
+		client,
 	}, nil
 }
 

--- a/pkg/targets/ceresdb/processor.go
+++ b/pkg/targets/ceresdb/processor.go
@@ -14,12 +14,7 @@ type processor struct {
 	client ceresdb.Client
 }
 
-func (p *processor) Init(workerNum int, doLoad, hashWorkers bool) {
-	client, err := ceresdb.NewClient(p.addr, ceresdb.Direct, ceresdb.WithDefaultDatabase("public"))
-	if err != nil {
-		panic(err)
-	}
-	p.client = client
+func (p *processor) Init(_ int, _, _ bool) {
 }
 
 func (p *processor) ProcessBatch(b targets.Batch, doLoad bool) (metricCount, rowCount uint64) {


### PR DESCRIPTION
Currently, ceresdb client is created for every worker when loading data into ceresdb, but this is not the best practice. This PR tries to reuse the same ceresdb client across different write workers.